### PR TITLE
Avoid PHP 8.2+ deprecation warnings on creating dynamic properties

### DIFF
--- a/CachePlaceholders.module
+++ b/CachePlaceholders.module
@@ -2,7 +2,7 @@
 
 namespace ProcessWire;
 
-class CachePlaceholders extends Wire implements Module
+class CachePlaceholders extends WireData implements Module
 {
     /** @var bool Whether the automatic page render hook is active */
     public $PageRenderHookActive;
@@ -24,12 +24,6 @@ class CachePlaceholders extends Wire implements Module
 
     /** @var string The delimiter for multivalue parameters */
     public $DelimiterMultivalue;
-
-    /** @var bool Property used by ProcessWire's module system for uninstallation */
-    public $uninstall;
-    
-    /** @var bool Property used by ProcessWire's module system for saving configuration */
-    public $submit_save_module;
 
     /** @var string The default start delimiter for tokens. */
     public const DEFAULT_DELIMITER_START = '{{{';

--- a/CachePlaceholders.module
+++ b/CachePlaceholders.module
@@ -25,6 +25,12 @@ class CachePlaceholders extends Wire implements Module
     /** @var string The delimiter for multivalue parameters */
     public $DelimiterMultivalue;
 
+    /** @var bool Property used by ProcessWire's module system for uninstallation */
+    public $uninstall;
+    
+    /** @var bool Property used by ProcessWire's module system for saving configuration */
+    public $submit_save_module;
+
     /** @var string The default start delimiter for tokens. */
     public const DEFAULT_DELIMITER_START = '{{{';
 


### PR DESCRIPTION
Adding explicit declarations for the properties:
public $uninstall 
public $submit_save_module
Both used by ProcessWire's module system during configuration saving